### PR TITLE
apt-prepper, enlighten and web-tester, Linux-oriented templates

### DIFF
--- a/0_hackathon-incomplete/apt-prepper/azuredeploy.json
+++ b/0_hackathon-incomplete/apt-prepper/azuredeploy.json
@@ -252,7 +252,7 @@
                     "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('availabilitySetName'))]"
                 },
                 "hardwareProfile": {
-                    "vmSize": "[parameters('vmSize')]"
+                    "vmSize": "[variables('vmSize')]"
                 },
                 "osProfile": {
                     "computername": "[concat(variables('vmName'),'cli', copyindex())]",
@@ -263,8 +263,7 @@
                     "sourceImage": {
                         "id": "[variables('sourceImageName')]"
                     },
-                    "destinationVhdsContainer": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/vhds/')]",
-
+                    "destinationVhdsContainer": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/vhds/')]",
                 },
                 "networkProfile": {
                     "networkInterfaces": [

--- a/0_hackathon-incomplete/apt-prepper/azuredeploy.json
+++ b/0_hackathon-incomplete/apt-prepper/azuredeploy.json
@@ -1,0 +1,324 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+		"prefix": {
+			"type": "string",
+			"defaultValue": "pfx"
+		},
+        "storageAccount": {
+            "type": "string",
+			"defaultValue": "stg"
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "West US"
+        },
+        "adminUsername": {
+            "type": "string",
+			"defaultValue": "azureuser"
+        },
+        "adminPassword": {
+            "type": "securestring"
+        },
+        "vmSourceImageName": {
+            "type": "string",
+            "defaultValue": "b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-14_04_2_LTS-amd64-server-20150309-en-us-30GB"
+        },
+        "subscriptionId": {
+            "type": "string"
+        },
+		"callURIRepOp": {
+			"type": "securestring"
+		},
+		"callURI": {
+			"type": "string"
+		},
+		"instances": {
+			"type": "int",
+			"defaultValue": 2
+		},
+		"platformFaultDomainCount": {
+            "type": "string",
+            "defaultValue": "2"
+        },
+        "platformUpdateDomainCount": {
+            "type": "string",
+            "defaultValue": "5"
+        }
+    },
+    "variables": {
+        "nicName": "[concat(parameters('prefix'),'nic')]",
+        "addressPrefix": "10.0.0.0/16",
+        "subnetName": "Subnet-1",
+        "subnetPrefix": "10.0.0.0/24",
+        "storageAccountType": "Standard_LRS",
+        "publicIPAddressName": "[concat(parameters('prefix'),'pip')]",
+        "publicIPAddressType": "Dynamic",
+        "vmStorageAccountContainerName": "vhds",
+        "vmName": "[concat(parameters('prefix'),'vm')]",
+        "vmSize": "Standard_A3",
+        "virtualNetworkName": "[concat(parameters('prefix'),'vnet')]",
+        "sourceImageName": "[concat('/',parameters('subscriptionId'),'/services/images/',parameters('vmSourceImageName'))]",
+        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+		"storageAccountName": "[concat(parameters('prefix'),parameters('storageAccount'))]",
+		"serverFarmName": "[concat(parameters('prefix'),'frm')]",
+		"siteName": "[concat(parameters('prefix'),'web')]",
+		"callURI": "[concat(parameters('callURI'),'?SiteName=',variables('siteName'))]",
+		"availabilitySetName": "[concat(parameters('prefix'),'avset')]",
+		"callURIRepOp": "[concat(parameters('callURIRepOp'),'&SiteName=',variables('siteName'))]"
+    },
+    "resources": [
+		{
+			"type": "Microsoft.Web/serverfarms",
+			"apiVersion": "2014-06-01",
+			"name": "[variables('serverFarmName')]",
+			"location": "[parameters('location')]",
+			"properties": {
+				"sku": "Free"
+			}			
+		},
+		{
+			"type": "Microsoft.Web/sites",
+			"apiVersion": "2014-06-01",
+			"dependsOn": ["[concat('Microsoft.Web/serverfarms/', variables('serverFarmName'))]"],
+			"name": "[variables('siteName')]",
+			"location": "[parameters('location')]",
+			"properties": {
+				"serverFarm": "[variables('serverFarmName')]"
+			}
+			
+		},
+		{
+            "type": "Microsoft.Compute/availabilitySets",
+            "name": "[variables('availabilitySetName')]",
+            "apiVersion": "2014-12-01-preview",
+            "location": "[parameters('location')]",
+            "properties": {
+                "platformFaultDomainCount": "[parameters('platformFaultDomainCount')]",
+                "platformUpdateDomainCount": "[parameters('platformUpdateDomainCount')]"
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[variables('storageAccountName')]",
+            "apiVersion": "2014-12-01-preview",
+            "location": "[parameters('location')]",
+            "properties": {
+                "accountType": "[variables('storageAccountType')]"
+            }
+        },
+        {
+            "apiVersion": "2014-12-01-preview",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "name": "[variables('publicIPAddressName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+                "dnsSettings": {
+                    "domainNameLabel": "[variables('vmName')]"
+                }
+            }
+        },
+        {
+            "apiVersion": "2014-12-01-preview",
+            "type": "Microsoft.Network/virtualNetworks",
+            "name": "[variables('virtualNetworkName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "[variables('addressPrefix')]"
+                    ]
+                },
+                "subnets": [
+                    {
+                        "name": "[variables('subnetName')]",
+                        "properties": {
+                            "addressPrefix": "[variables('subnetPrefix')]"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2014-12-01-preview",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[variables('nicName')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+                "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+                            },
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+		{
+            "apiVersion": "2014-12-01-preview",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[concat('niccli', copyindex())]",
+            "location": "[parameters('location')]",
+            "copy": {
+                "name": "clientNicLoop",
+                "count": "[parameters('instances')]"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2014-12-01-preview",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[variables('vmName')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]",
+				"[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]"
+            ],
+            "properties": {
+				"availabilitySet": {
+                    "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('availabilitySetName'))]"
+                },
+                "hardwareProfile": {
+                    "vmSize": "[variables('vmSize')]"
+                },
+                "osProfile": {
+                    "computername": "[variables('vmName')]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                    "sourceImage": {
+                        "id": "[variables('sourceImageName')]"
+                    },
+                    "destinationVhdsContainer": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/')]"
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+                        }
+                    ]
+                }
+            }
+        },
+		{
+            "apiVersion": "2014-12-01-preview",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[concat(variables('vmName'),'cli', copyindex())]",
+            "location": "[parameters('location')]",
+            "copy": {
+                "name": "cli-loop",
+                "count": "[parameters('instances')]"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.Network/networkInterfaces/', 'niccli', copyindex())]",
+                "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), '/extensions/prepare_ops')]",
+                "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+                "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]"
+            ],
+            "properties": {
+                "availabilitySet": {
+                    "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('availabilitySetName'))]"
+                },
+                "hardwareProfile": {
+                    "vmSize": "[parameters('vmSize')]"
+                },
+                "osProfile": {
+                    "computername": "[concat(variables('vmName'),'cli', copyindex())]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                    "sourceImage": {
+                        "id": "[variables('sourceImageName')]"
+                    },
+                    "destinationVhdsContainer": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/vhds/')]",
+
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces',concat('niccli', copyindex()))]"
+                        }
+                    ]
+                }
+            }
+        },
+		{
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "name": "[concat(variables('vmName'),'/prepare_ops')]",
+            "apiVersion": "2014-12-01-preview",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
+            ],
+            "properties": {
+                "publisher": "Microsoft.OSTCExtensions",
+                "type": "CustomScriptForLinux",
+                "typeHandlerVersion": "1.2",
+                "settings": {
+                    "fileUris": [
+                        "[variables('callURIRepOp')]"
+                    ],
+                    "commandToExecute": "sh apt-prepare.sh"
+                }
+            }
+        },
+		{
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+			"name": "[concat(variables('vmName'), 'cli', copyindex(), '/enable_repo')]",
+            "apiVersion": "2014-12-01-preview",
+            "location": "[parameters('location')]",
+            "copy": {
+                "name": "extensionLoop",
+                "count": "[parameters('instances')]"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), 'cli', copyindex())]",
+                "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
+            ],
+            "properties": {
+                "publisher": "Microsoft.OSTCExtensions",
+                "type": "CustomScriptForLinux",
+                "typeHandlerVersion": "1.2",
+                "settings": {
+                    "fileUris": [
+                        "[variables('callURI')]"
+                    ],
+                    "commandToExecute": "sh apt-enable.sh"
+                }
+            }
+        }
+    ]
+}

--- a/0_hackathon-incomplete/apt-prepper/azuredeploy.parameters.json
+++ b/0_hackathon-incomplete/apt-prepper/azuredeploy.parameters.json
@@ -1,0 +1,14 @@
+{
+        "adminPassword": {
+            "value": "..."
+        },
+        "subscriptionId": {
+            "value": "..."
+        },
+		"callURIRepOp": {
+			"value": "http://.../apt-prepare.sh?DepUser=...&DepPass=..."
+		},
+		"callURI": {
+			"value": "http://.../apt-enable.sh"
+		}
+}

--- a/0_hackathon-incomplete/apt-prepper/metadata.json
+++ b/0_hackathon-incomplete/apt-prepper/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "An APT repository in the cloud for a group of APT-based VMs",
+  "description": "This template deploys instances+1 APT-based (Ubuntu by default) VMs and configures a Web Site which will serve as an APT repository"
+  "summary": "This template deploys instances+1 APT-based (Ubuntu by default) VMs and configures a Web Site which will serve as an APT repository"
+  "githubUsername": "bureado",
+  "dateUpdated": "2015-04-10"
+}

--- a/0_hackathon-incomplete/enlighten/azuredeploy.json
+++ b/0_hackathon-incomplete/enlighten/azuredeploy.json
@@ -1,0 +1,180 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+		"prefix": {
+			"type": "string",
+			"defaultValue": "pfx"
+		},
+        "storageAccount": {
+            "type": "string",
+			"defaultValue": "stg"
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "West US"
+        },
+        "adminUsername": {
+            "type": "string",
+			"defaultValue": "azureuser"
+        },
+        "adminPassword": {
+            "type": "securestring"
+        },
+        "vmDNSName": {
+            "type": "string",
+			"defaultValue": "vm"
+        },
+        "vmSourceImageName": {
+            "type": "string",
+            "defaultValue": "b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-14_04_2_LTS-amd64-server-20150309-en-us-30GB"
+        },
+        "subscriptionId": {
+            "type": "string"
+        },
+		"callURI": {
+			"type": "securestring"
+		}
+    },
+    "variables": {
+        "nicName": "[concat(parameters('prefix'),'nic')]",
+        "addressPrefix": "10.0.0.0/16",
+        "subnetName": "Subnet-1",
+        "subnetPrefix": "10.0.0.0/24",
+        "storageAccountType": "Standard_LRS",
+        "publicIPAddressName": "[concat(parameters('prefix'),'pip')]",
+        "publicIPAddressType": "Dynamic",
+        "vmStorageAccountContainerName": "vhds",
+        "vmName": "[concat(parameters('prefix'),'vm')]",
+        "vmSize": "Standard_A3",
+        "virtualNetworkName": "[concat(parameters('prefix'),'vnet')]",
+        "sourceImageName": "[concat('/',parameters('subscriptionId'),'/services/images/',parameters('vmSourceImageName'))]",
+        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+		"storageAccountName": "[concat(parameters('prefix'),parameters('storageAccount'))]",
+		"callURI": "[parameters("callURI")]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[variables('storageAccountName')]",
+            "apiVersion": "2014-12-01-preview",
+            "location": "[parameters('location')]",
+            "properties": {
+                "accountType": "[variables('storageAccountType')]"
+            }
+        },
+        {
+            "apiVersion": "2014-12-01-preview",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "name": "[variables('publicIPAddressName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+                "dnsSettings": {
+                    "domainNameLabel": "[variables('vmName')]"
+                }
+            }
+        },
+        {
+            "apiVersion": "2014-12-01-preview",
+            "type": "Microsoft.Network/virtualNetworks",
+            "name": "[variables('virtualNetworkName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "[variables('addressPrefix')]"
+                    ]
+                },
+                "subnets": [
+                    {
+                        "name": "[variables('subnetName')]",
+                        "properties": {
+                            "addressPrefix": "[variables('subnetPrefix')]"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2014-12-01-preview",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[variables('nicName')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+                "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+                            },
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2014-12-01-preview",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[variables('vmName')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[variables('vmSize')]"
+                },
+                "osProfile": {
+                    "computername": "[variables('vmName')]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                    "sourceImage": {
+                        "id": "[variables('sourceImageName')]"
+                    },
+                    "destinationVhdsContainer": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/')]"
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+                        }
+                    ]
+                }
+            }
+        },
+		{
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "name": "[concat(variables('vmName'),'/enlighten')]",
+            "apiVersion": "2014-12-01-preview",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
+            ],
+            "properties": {
+                "publisher": "Microsoft.OSTCExtensions",
+                "type": "CustomScriptForLinux",
+                "typeHandlerVersion": "1.2",
+                "settings": {
+                    "fileUris": [
+                        "[variables("callURI")]",
+                    ],
+                    "commandToExecute": "sh enlighten-automatic.sh"
+                }
+            }
+        }
+    ]
+}

--- a/0_hackathon-incomplete/enlighten/azuredeploy.parameters.json
+++ b/0_hackathon-incomplete/enlighten/azuredeploy.parameters.json
@@ -1,0 +1,11 @@
+{
+        "adminPassword": {
+            "value": ""
+        },
+        "subscriptionId": {
+            "value": ""
+        },
+		"callURI": {
+			"value": "http://.../enlighten-automatic.sh?SGSecret=..."
+		}
+}

--- a/0_hackathon-incomplete/enlighten/metadata.json
+++ b/0_hackathon-incomplete/enlighten/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "Linux VM with preconfigured azure-cli",
+  "description": "This template deploys an APT-based Linux VM (Ubuntu by default) and uses scriptgen to install and preconfigures azure-cli",
+  "summary": "This template deploys an APT-based Linux VM (Ubuntu by default) and uses scriptgen to install and preconfigures azure-cli",
+  "githubUsername": "bureado",
+  "dateUpdated": "2015-04-10"
+}

--- a/0_hackathon-incomplete/web-tester/azuredeploy.json
+++ b/0_hackathon-incomplete/web-tester/azuredeploy.json
@@ -1,0 +1,202 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+		"prefix": {
+			"type": "string",
+			"defaultValue": "pfx"
+		},
+        "storageAccount": {
+            "type": "string",
+			"defaultValue": "stg"
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "West US"
+        },
+        "adminUsername": {
+            "type": "string",
+			"defaultValue": "azureuser"
+        },
+        "adminPassword": {
+            "type": "securestring"
+        },
+        "vmDNSName": {
+            "type": "string",
+			"defaultValue": "vm"
+        },
+        "vmSourceImageName": {
+            "type": "string",
+            "defaultValue": "b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-14_04_2_LTS-amd64-server-20150309-en-us-30GB"
+        },
+        "subscriptionId": {
+            "type": "string"
+        },
+		"callURI": {
+			"type": "securestring"
+		}
+    },
+    "variables": {
+        "nicName": "[concat(parameters('prefix'),'nic')]",
+        "addressPrefix": "10.0.0.0/16",
+        "subnetName": "Subnet-1",
+        "subnetPrefix": "10.0.0.0/24",
+        "storageAccountType": "Standard_LRS",
+        "publicIPAddressName": "[concat(parameters('prefix'),'pip')]",
+        "publicIPAddressType": "Dynamic",
+        "vmStorageAccountContainerName": "vhds",
+        "vmName": "[concat(parameters('prefix'),'vm')]",
+        "vmSize": "Standard_A3",
+        "virtualNetworkName": "[concat(parameters('prefix'),'vnet')]",
+        "sourceImageName": "[concat('/',parameters('subscriptionId'),'/services/images/',parameters('vmSourceImageName'))]",
+        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+		"storageAccountName": "[concat(parameters('prefix'),parameters('storageAccount'))]",
+		"serverFarmName": "[concat(parameters('prefix'),'frm')]",
+		"siteName": "[concat(parameters('prefix'),'web')]",
+		"callURI": "[concat(parameters('callURI'),'&SiteName=',variables('siteName'))]"
+    },
+    "resources": [
+		{
+			"type": "Microsoft.Web/serverfarms",
+			"apiVersion": "2014-06-01",
+			"name": "[variables('serverFarmName')]",
+			"location": "[parameters('location')]",
+			"properties": {
+				"sku": "Free"
+			}			
+		},
+		{
+			"type": "Microsoft.Web/sites",
+			"apiVersion": "2014-06-01",
+			"dependsOn": ["[concat('Microsoft.Web/serverfarms/', variables('serverFarmName'))]"],
+			"name": "[variables('siteName')]",
+			"location": "[parameters('location')]",
+			"properties": {
+				"serverFarm": "[variables('serverFarmName')]"
+			}
+			
+		},
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[variables('storageAccountName')]",
+            "apiVersion": "2014-12-01-preview",
+            "location": "[parameters('location')]",
+            "properties": {
+                "accountType": "[variables('storageAccountType')]"
+            }
+        },
+        {
+            "apiVersion": "2014-12-01-preview",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "name": "[variables('publicIPAddressName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+                "dnsSettings": {
+                    "domainNameLabel": "[variables('vmName')]"
+                }
+            }
+        },
+        {
+            "apiVersion": "2014-12-01-preview",
+            "type": "Microsoft.Network/virtualNetworks",
+            "name": "[variables('virtualNetworkName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "[variables('addressPrefix')]"
+                    ]
+                },
+                "subnets": [
+                    {
+                        "name": "[variables('subnetName')]",
+                        "properties": {
+                            "addressPrefix": "[variables('subnetPrefix')]"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2014-12-01-preview",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[variables('nicName')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+                "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+                            },
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2014-12-01-preview",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[variables('vmName')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[variables('vmSize')]"
+                },
+                "osProfile": {
+                    "computername": "[variables('vmName')]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                    "sourceImage": {
+                        "id": "[variables('sourceImageName')]"
+                    },
+                    "destinationVhdsContainer": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/')]"
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+                        }
+                    ]
+                }
+            }
+        },
+		{
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "name": "[concat(variables('vmName'),'/run_test')]",
+            "apiVersion": "2014-12-01-preview",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
+            ],
+            "properties": {
+                "publisher": "Microsoft.OSTCExtensions",
+                "type": "CustomScriptForLinux",
+                "typeHandlerVersion": "1.2",
+                "settings": {
+                    "fileUris": [
+                        "[variables('callURI')]"
+                    ],
+                    "commandToExecute": "sh php-test.sh"
+                }
+            }
+        }
+    ]
+}

--- a/0_hackathon-incomplete/web-tester/azuredeploy.parameters.json
+++ b/0_hackathon-incomplete/web-tester/azuredeploy.parameters.json
@@ -1,0 +1,11 @@
+{
+        "adminPassword": {
+            "value": "..."
+        },
+        "subscriptionId": {
+            "value": "..."
+        },
+	"callURI": {
+		"value": "http://.../php-test.sh?DepUser=...&DepPass=..."
+	}
+}

--- a/0_hackathon-incomplete/web-tester/metadata.json
+++ b/0_hackathon-incomplete/web-tester/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "A PHP Web Site with a companion Linux/Apache server",
+  "description": "This template deploys an APT-based Linux VM (Ubuntu by default) and a Web Site and connects them via git for test/production",
+  "summary": "This template deploys an APT-based Linux VM (Ubuntu by default) and a Web Site and connects them via git for test/production",
+  "githubUsername": "bureado",
+  "dateUpdated": "2015-04-10"
+}


### PR DESCRIPTION
Both templates call `scriptgen` (https://github.com/bureado/scriptgen) to generate scripts that either help provision `azure-cli` or are self-aware of other resources (i.e., web site) and clone them via git.

To learn more, check this short deck out: http://1drv.ms/1axWUfW
