### PR TITLE
ARM template for CoreOS cluster with Fleet

### DIFF
--- a/coreos-with-fleet-multivm/README.md
+++ b/coreos-with-fleet-multivm/README.md
@@ -48,6 +48,7 @@ This file must be base64 encoded and set as the customData value in azuredeploy-
 Below are the parameters that the template expects
 
 | Name   | Description    |
+|:--- |:---|
 | location | location where the resources will be deployed |
 | newStorageAccountName | new storage account for the VMs OS disk |
 | vmNamePrefix | prefix for the names of each VM |

--- a/coreos-with-fleet-multivm/README.md
+++ b/coreos-with-fleet-multivm/README.md
@@ -1,0 +1,60 @@
+# Deploy a Virtual Machine with SSH Keys
+
+<a href="https://azuredeploy.net/" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+
+This template allows you to create a CoreOS cluster with Fleet deployed and started on each cluster node. This template also deploys a Storage Account, Virtual Network, Public IP addresses and a Network Interface. 
+
+You will need to provide a key pair for authentication to the nodes as well as a cloud-config.yaml file to configure Fleet.
+
+Step-1: Generate a OpenSSH Key Pair. You will get a public and private key. The private key will be of the format : -----BEGIN RSA PRIVATE KEY-----base64encodedprivatekey-----END RSA PRIVATE KEY-----
+
+Step-2: Now use openssl to get a public certificate for the generated private key. The following sample command should help you do that: openssl.exe req -x509 -days 365 -new -key "<Path>\privatekeyopenssh.pem" -out "publickeycert.cer" -config openssl.cnf. The certificate generated should be this format - -----BEGIN CERTIFICATE-----base64encodedpublickey-----END CERTIFICATE-----
+
+Step-3: In the template file, you need to pass the base64encodedpublickey (after stripping off Begin and End Certificate header) as the sshKeyData value.
+
+Note: In the next few weeks, we will make a breaking API change to update the APIs to accept the sshKeyData in the following format - ssh-rsa <publickey> keyComment.
+
+
+The cloud-config.yaml file requires a distinct discovery ID to identify the cluster. You can use the CoreOS discovery service to generate the discovery ID by running the following command:
+
+curl https://discovery.etcd.io/new | grep ^http.* > etcdid
+
+This will provide a token like the following that must be inserted in the cloud-config.yaml file:
+
+https://discovery.etcd.io/dcf78d9803b417e1a3eeb15987bdf82f
+
+The following is a sample cloud-config.yaml file:
+
+#cloud-config
+
+coreos:
+  etcd:
+    # generate a new token for each unique cluster from https://discovery.etcd.io/new
+    discovery: https://discovery.etcd.io/dcf78d9803b417e1a3eeb15987bdf82f
+    # deployments across multiple cloud services will need to use $public_ipv4
+    addr: $private_ipv4:4001
+    peer-addr: $private_ipv4:7001
+  units:
+    - name: etcd.service
+      command: start
+    - name: fleet.service
+      command: start
+
+This file must be base64 encoded and set as the customData value in azuredeploy-parameters.json
+
+
+Below are the parameters that the template expects
+
+| Name   | Description    |
+| location | location where the resources will be deployed |
+| newStorageAccountName | new storage account for the VMs OS disk |
+| vmNamePrefix | prefix for the names of each VM |
+| virtualNetworkName | name for the new VNET |
+| vmSourceImageName" | name of the3 CoreOS image |
+| vmSize | Instance size for the VMs |
+| adminUsername | Name of the admin user | 
+| sshKeyData | Explained above |
+| customData | Explained above |
+| subscriptionId | Azure subscription ID |

--- a/coreos-with-fleet-multivm/azuredeploy-parameters.json
+++ b/coreos-with-fleet-multivm/azuredeploy-parameters.json
@@ -1,0 +1,32 @@
+﻿{
+    "location": {
+        "value": "West US"
+    },
+    "newStorageAccountName" : {
+        "value":""
+    },
+    "vmNamePrefix" : {
+      "value" : ""
+    },
+    "virtualNetworkName": {
+        "value": ""
+    },
+    "vmSourceImageName" : {
+        "value" : ""
+    },
+    "vmSize": {
+        "value": "Standard_A1"
+    },
+    "adminUsername": {
+        "value": ""
+    },
+    "sshKeyData" : {
+        "value" : ""
+    },
+    "customData" : {
+        "value" : ""
+    },
+    "subscriptionId": {
+        "value": ""
+    }
+}

--- a/coreos-with-fleet-multivm/azuredeploy-parameters.json
+++ b/coreos-with-fleet-multivm/azuredeploy-parameters.json
@@ -25,8 +25,5 @@
     },
     "customData" : {
         "value" : ""
-    },
-    "subscriptionId": {
-        "value": ""
     }
 }

--- a/coreos-with-fleet-multivm/azuredeploy.json
+++ b/coreos-with-fleet-multivm/azuredeploy.json
@@ -33,9 +33,6 @@
         },
         "customData": {
             "type": "string"
-        },
-        "subscriptionId": {
-            "type": "string"
         }
     },
     "variables": {
@@ -48,7 +45,7 @@
         "publicIPAddressType": "Dynamic",
         "storageAccountType": "Standard_LRS",
         "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
-        "sourceImageName": "[concat('/',parameters('subscriptionId'),'/services/images/',parameters('vmSourceImageName'))]",
+        "sourceImageName": "[concat('/',subscription().subscriptionId,'/services/images/',parameters('vmSourceImageName'))]",
         "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
         "subnet1Ref": "[concat(variables('vnetID'),'/subnets/',variables('subnet1Name'))]"
     },

--- a/coreos-with-fleet-multivm/azuredeploy.json
+++ b/coreos-with-fleet-multivm/azuredeploy.json
@@ -4,35 +4,62 @@
     "parameters": {
         "location": {
             "type": "String",
-            "defaultValue": "West US"
+            "defaultValue": "West US",
+            "metadata": { 
+                 "Description": "Location of resources" 
+            } 
         },
         "newStorageAccountName": {
-            "type": "string"
+            "type": "string",
+            "metadata": { 
+                 "Description": "Name of the of the storage account for VM OS Disk"
+            } 
         },
         "vmNamePrefix": {
             "type": "string",
-            "defaultValue": "coreos"
+            "defaultValue": "coreos",
+            "metadata": { 
+                 "Description": "Prefix for the names of the VMs"
+            } 
         },
         "virtualNetworkName": {
             "type": "string",
-            "defaultValue": "myVNET"
+            "defaultValue": "myVNET",
+            "metadata": { 
+                 "Description": "Name of the VNET hosting the VMs"
+            } 
         },
         "vmSourceImageName": {
             "type": "string",
-            "defaultValue": "2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-607.0.0"
+            "defaultValue": "2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-607.0.0",
+            "metadata": { 
+                 "Description": "Name of the CoreOS image"
+            } 
         },
         "vmSize": {
             "type": "string",
-            "defaultValue": "Standard_A1"
+            "defaultValue": "Standard_A1",
+            "metadata": { 
+                 "Description": "Instance size for the VMs"
+            } 
         },
         "adminUserName": {
-            "type": "string"
+            "type": "string",
+            "metadata": { 
+                 "Description": "Username to login to the VMs"
+            } 
         },
         "sshKeyData": {
-            "type": "string"
+            "type": "string",
+            "metadata": { 
+                 "Description": "Public key for SSH authentication"
+            } 
         },
         "customData": {
-            "type": "string"
+            "type": "string",
+            "metadata": { 
+                 "Description": "Base64-encoded cloud-config.yaml file to deploy and start Fleet"
+            } 
         }
     },
     "variables": {

--- a/coreos-with-fleet-multivm/azuredeploy.json
+++ b/coreos-with-fleet-multivm/azuredeploy.json
@@ -1,0 +1,178 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "location": {
+            "type": "String",
+            "defaultValue": "West US"
+        },
+        "newStorageAccountName": {
+            "type": "string"
+        },
+        "vmNamePrefix": {
+            "type": "string",
+            "defaultValue": "coreos"
+        },
+        "virtualNetworkName": {
+            "type": "string",
+            "defaultValue": "myVNET"
+        },
+        "vmSourceImageName": {
+            "type": "string",
+            "defaultValue": "2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-607.0.0"
+        },
+        "vmSize": {
+            "type": "string",
+            "defaultValue": "Standard_A1"
+        },
+        "adminUserName": {
+            "type": "string"
+        },
+        "sshKeyData": {
+            "type": "string"
+        },
+        "customData": {
+            "type": "string"
+        },
+        "subscriptionId": {
+            "type": "string"
+        }
+    },
+    "variables": {
+        "numberOfNodes": 3,
+        "addressPrefix": "10.0.0.0/16",
+        "subnet1Name": "Subnet-1",
+        "subnet2Name": "Subnet-2",
+        "subnet1Prefix": "10.0.0.0/24",
+        "vmStorageAccountContainerName": "vhds",
+        "publicIPAddressType": "Dynamic",
+        "storageAccountType": "Standard_LRS",
+        "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
+        "sourceImageName": "[concat('/',parameters('subscriptionId'),'/services/images/',parameters('vmSourceImageName'))]",
+        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
+        "subnet1Ref": "[concat(variables('vnetID'),'/subnets/',variables('subnet1Name'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[parameters('newStorageAccountName')]",
+            "location": "[parameters('location')]",
+            "apiVersion": "2014-12-01-preview",
+            "properties": {
+                "accountType": "[variables('storageAccountType')]"
+            }
+        },
+        {
+            "type": "Microsoft.Network/publicIPAddresses",
+            "name": "[concat('publicIP', copyindex())]",
+            "copy": {
+                "name": "ipLoop",
+                "count": "[variables('numberOfNodes')]"
+            },
+            "location": "[parameters('location')]",
+            "apiVersion": "2014-12-01-preview",
+            "properties": {
+                "publicIPAllocationMethod": "[variables('publicIPAddressType')]"
+            }
+        },
+        {
+            "type": "Microsoft.Network/virtualNetworks",
+            "name": "[parameters('virtualNetworkName')]",
+            "location": "[parameters('location')]",
+            "apiVersion": "2014-12-01-preview",
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "[variables('addressPrefix')]"
+                    ]
+                },
+                "subnets": [
+                    {
+                        "name": "[variables('subnet1Name')]",
+                        "properties": {
+                            "addressPrefix": "[variables('subnet1Prefix')]"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[concat('nic', copyindex())]",
+            "copy": {
+                "name": "nicLoop",
+                "count": "[variables('numberOfNodes')]"
+            },
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', 'publicIP', copyindex())]",
+                "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]"
+            ],
+            "apiVersion": "2014-12-01-preview",
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIpAddresses', concat('publicIP', copyindex()))]"
+                            },
+                            "subnet": {
+                                "id": "[variables('subnet1Ref')]"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[concat(parameters('vmNamePrefix'), copyindex())]",
+            "copy": {
+                "name": "virtualMachineLoop",
+                "count": "[variables('numberOfNodes')]"
+            },
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', 'nic', copyindex())]"
+            ],
+            "apiVersion": "2014-12-01-preview",
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[parameters('vmSize')]"
+                },
+                "osProfile": {
+                    "computername": "[concat(parameters('vmNamePrefix'), copyindex())]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "customData": "[parameters('customData')]",
+                    "linuxConfiguration": {
+                        "disablePasswordAuthentication": "true",
+                        "ssh": {
+                            "publicKeys": [
+                                {
+                                    "path": "[variables('sshKeyPath')]",
+                                    "keyData": "[parameters('sshKeyData')]"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "storageProfile": {
+                    "sourceImage": {
+                        "id": "[variables('sourceImageName')]"
+                    },
+                    "destinationVhdsContainer": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/')]"
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces',concat('nic',copyindex()))]"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/coreos-with-fleet-multivm/cloud-config.yaml
+++ b/coreos-with-fleet-multivm/cloud-config.yaml
@@ -1,0 +1,14 @@
+#cloud-config
+
+coreos:
+  etcd:
+    # generate a new token for each unique cluster from https://discovery.etcd.io/new
+    discovery: https://discovery.etcd.io/dcf78d9803b417e1a3eeb15987bdf82f
+    # deployments across multiple cloud services will need to use $public_ipv4
+    addr: $private_ipv4:4001
+    peer-addr: $private_ipv4:7001
+  units:
+    - name: etcd.service
+      command: start
+    - name: fleet.service
+      command: start

--- a/coreos-with-fleet-multivm/metadata.json
+++ b/coreos-with-fleet-multivm/metadata.json
@@ -1,0 +1,6 @@
+{ 
+  "itemDisplayName": "Spin up a 3-node CoreOS cluster with Fleet", 
+  "description": "Template spins up a CoreOS cluster with Fleet deployed deployed and started on each cluster node.", 
+  "githubUsername": "nmackenzie", 
+  "dateUpdated": "2015-04-10" 
+} 

--- a/coreos-with-fleet-multivm/metadata.json
+++ b/coreos-with-fleet-multivm/metadata.json
@@ -2,5 +2,6 @@
   "itemDisplayName": "Spin up a 3-node CoreOS cluster with Fleet", 
   "description": "Template spins up a CoreOS cluster with Fleet deployed deployed and started on each cluster node.", 
   "githubUsername": "nmackenzie", 
+  "summary": "CoreOS cluster with Fleet deployed on each node",
   "dateUpdated": "2015-04-10" 
 } 


### PR DESCRIPTION
This template creates a 3-node CoreOS cluster with  Fleet deployed onto each node. This can be used to schedule Docker containers onto any of the nodes in the cluster.
