### PR TITLE
Fix script URLs that changed after rename

### DIFF
--- a/memcached-multi-vm-ubuntu/azuredeploy.json
+++ b/memcached-multi-vm-ubuntu/azuredeploy.json
@@ -90,7 +90,8 @@
         "subnetDmzRef": "[concat(variables('vnetID'),'/subnets/',parameters('subnetDmzName'))]",
         "subnetMemcachedRef": "[concat(variables('vnetID'),'/subnets/',parameters('subnetMemcachedName'))]",
         "memcachedMachineNamePrefix": "memcached",
-        "scriptUrl": "https://raw.githubusercontent.com/azurermtemplates/azurermtemplates/master/memcached-multi-vm-ubuntu/"
+        "scriptUrlInstallMemcached": "https://raw.githubusercontent.com/azurermtemplates/azurermtemplates/master/memcached-multi-vm-ubuntu/install_memcached.sh",
+        "scriptUrlInstallApache": "https://raw.githubusercontent.com/azurermtemplates/azurermtemplates/master/memcached-multi-vm-ubuntu/install_apache.sh"
     },
     "resources": [
         {
@@ -281,7 +282,7 @@
                 "typeHandlerVersion": "1.2",
                 "settings": {
                     "fileUris": [
-                        "[concat(variables('scriptUrl'), 'install_memcached.sh')]"
+                        "[variables('scriptUrlInstallMemcached')]"
                     ],
                     "commandToExecute": "[concat('sh install_memcached.sh ', copyindex(), ' ', reference(concat('nicmemcached', copyindex())).ipConfigurations[0].properties.privateIPAddress, ' ', reference('nicapache').ipConfigurations[0].properties.privateIPAddress)]"
                 }
@@ -301,7 +302,7 @@
                 "typeHandlerVersion": "1.2",
                 "settings": {
                     "fileUris": [
-                        "[concat(variables('scriptUrl'), 'install_apache.sh')]"
+                        "[variables('scriptUrlInstallApache')]"
                     ],
                     "commandToExecute": "[concat('sh install_apache.sh ', parameters('numberOfMemcachedInstances'), ' ', parameters('subnetMemcachedPrefix'))]"
                 }

--- a/memcached-multi-vm-ubuntu/azuredeploy.json
+++ b/memcached-multi-vm-ubuntu/azuredeploy.json
@@ -89,7 +89,8 @@
         "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
         "subnetDmzRef": "[concat(variables('vnetID'),'/subnets/',parameters('subnetDmzName'))]",
         "subnetMemcachedRef": "[concat(variables('vnetID'),'/subnets/',parameters('subnetMemcachedName'))]",
-        "memcachedMachineNamePrefix": "memcached"
+        "memcachedMachineNamePrefix": "memcached",
+        "scriptUrl": "https://raw.githubusercontent.com/azurermtemplates/azurermtemplates/master/memcached-multi-vm-ubuntu/"
     },
     "resources": [
         {
@@ -280,7 +281,7 @@
                 "typeHandlerVersion": "1.2",
                 "settings": {
                     "fileUris": [
-                        "https://raw.githubusercontent.com/azurermtemplates/azurermtemplates/master/ubuntu-memcached-multi-vm/install_memcached.sh"
+                        "[concat(variables('scriptUrl'), 'install_memcached.sh')]"
                     ],
                     "commandToExecute": "[concat('sh install_memcached.sh ', copyindex(), ' ', reference(concat('nicmemcached', copyindex())).ipConfigurations[0].properties.privateIPAddress, ' ', reference('nicapache').ipConfigurations[0].properties.privateIPAddress)]"
                 }
@@ -300,7 +301,7 @@
                 "typeHandlerVersion": "1.2",
                 "settings": {
                     "fileUris": [
-                        "https://raw.githubusercontent.com/azurermtemplates/azurermtemplates/master/ubuntu-memcached-multi-vm/install_apache.sh"
+                        "[concat(variables('scriptUrl'), 'install_apache.sh')]"
                     ],
                     "commandToExecute": "[concat('sh install_apache.sh ', parameters('numberOfMemcachedInstances'), ' ', parameters('subnetMemcachedPrefix'))]"
                 }

--- a/memcached-multi-vm-ubuntu/install_apache.sh
+++ b/memcached-multi-vm-ubuntu/install_apache.sh
@@ -33,8 +33,8 @@ apt-get -y install apache2 php5 php5-memcached
 rm /var/www/html/index.html
  
 # Download cache_test.php page
-wget -O /var/www/html/index.php https://raw.githubusercontent.com/azurermtemplates/azurermtemplates/master/ubuntu-memcached-multi-vm/cache_test.php
- 
+wget -O /var/www/html/index.php https://raw.githubusercontent.com/azurermtemplates/azurermtemplates/master/memcached-multi-vm-ubuntu/cache_test.php
+
 # Replace the placeholder with the string of comma delimited memcached server IPs that was passed to this script as a parameter
 sed -i "s/{COMMA_DELIMITED_SERVERS_LIST}/$servers/g" /var/www/html/index.php
  

--- a/postgresql-multi-vm-ubuntu/azuredeploy.json
+++ b/postgresql-multi-vm-ubuntu/azuredeploy.json
@@ -138,7 +138,7 @@
         "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
         "subnetDmzRef": "[concat(variables('vnetID'),'/subnets/',parameters('subnetDmzName'))]",
         "subnetDbRef": "[concat(variables('vnetID'),'/subnets/',parameters('subnetDbName'))]",
-		"scriptUrl": "https://raw.githubusercontent.com/azurermtemplates/azurermtemplates/master/postgresql-multi-vm-ubuntu/"
+		"scriptUrlInstallPostgreSql": "https://raw.githubusercontent.com/azurermtemplates/azurermtemplates/master/postgresql-multi-vm-ubuntu/install_postgresql.sh"
     },
     "resources": [
         {
@@ -435,7 +435,7 @@
                 "typeHandlerVersion": "1.2",
                 "settings": {
                     "fileUris": [
-                        "[concat(variables('scriptUrl'), 'install_postgresql.sh')]"
+                        "[variables('scriptUrlInstallPostgreSql')]"
                     ],
                     "commandToExecute": "[concat('bash install_postgresql.sh ', reference('nicmaster').ipConfigurations[0].properties.privateIPAddress, ' ', parameters('subnetDbPrefix'), ' MASTER ', reference('nicmaster').ipConfigurations[0].properties.privateIPAddress, ' ', parameters('numberOfSlaveInstances'), ' ', parameters('replicatorPassword'))]"
                 }
@@ -460,7 +460,7 @@
                 "typeHandlerVersion": "1.2",
                 "settings": {
                     "fileUris": [
-                        "[concat(variables('scriptUrl'), 'install_postgresql.sh')]"
+                        "[variables('scriptUrlInstallPostgreSql')]"
                     ],
                     "commandToExecute": "[concat('bash install_postgresql.sh ', reference('nicmaster').ipConfigurations[0].properties.privateIPAddress, ' ', parameters('subnetDbPrefix'), ' SLAVE ', reference(concat('nicslave', copyindex())).ipConfigurations[0].properties.privateIPAddress, ' ', parameters('numberOfSlaveInstances'), ' ', parameters('replicatorPassword'))]"
                 }

--- a/postgresql-multi-vm-ubuntu/azuredeploy.json
+++ b/postgresql-multi-vm-ubuntu/azuredeploy.json
@@ -137,7 +137,8 @@
         "sourceImageName": "[concat('/',subscription().subscriptionId,'/services/images/',variables('vmSourceImageName'))]",
         "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
         "subnetDmzRef": "[concat(variables('vnetID'),'/subnets/',parameters('subnetDmzName'))]",
-        "subnetDbRef": "[concat(variables('vnetID'),'/subnets/',parameters('subnetDbName'))]"
+        "subnetDbRef": "[concat(variables('vnetID'),'/subnets/',parameters('subnetDbName'))]",
+		"scriptUrl": "https://raw.githubusercontent.com/azurermtemplates/azurermtemplates/master/postgresql-multi-vm-ubuntu/"
     },
     "resources": [
         {
@@ -434,7 +435,7 @@
                 "typeHandlerVersion": "1.2",
                 "settings": {
                     "fileUris": [
-                        "https://raw.githubusercontent.com/azurermtemplates/azurermtemplates/master/ubuntu-postgresql-multi-vm/install_postgresql.sh"
+                        "[concat(variables('scriptUrl'), 'install_postgresql.sh')]"
                     ],
                     "commandToExecute": "[concat('bash install_postgresql.sh ', reference('nicmaster').ipConfigurations[0].properties.privateIPAddress, ' ', parameters('subnetDbPrefix'), ' MASTER ', reference('nicmaster').ipConfigurations[0].properties.privateIPAddress, ' ', parameters('numberOfSlaveInstances'), ' ', parameters('replicatorPassword'))]"
                 }
@@ -459,7 +460,7 @@
                 "typeHandlerVersion": "1.2",
                 "settings": {
                     "fileUris": [
-                        "https://raw.githubusercontent.com/azurermtemplates/azurermtemplates/master/ubuntu-postgresql-multi-vm/install_postgresql.sh"
+                        "[concat(variables('scriptUrl'), 'install_postgresql.sh')]"
                     ],
                     "commandToExecute": "[concat('bash install_postgresql.sh ', reference('nicmaster').ipConfigurations[0].properties.privateIPAddress, ' ', parameters('subnetDbPrefix'), ' SLAVE ', reference(concat('nicslave', copyindex())).ipConfigurations[0].properties.privateIPAddress, ' ', parameters('numberOfSlaveInstances'), ' ', parameters('replicatorPassword'))]"
                 }


### PR DESCRIPTION
When template directory is renamed (e.g. from ubuntu-multi-vm-memcached
to memcached-multi-vm-ubuntu) the absolute github URIs within the json
templates  (e.g. settings.fileUris) continue pointing to the old folder
names and result in page not found. Are relative (to the template
location) settings.fileUris supported?
