### PR TITLE
Update the Mesosphere default config script commands

### DIFF
--- a/centos-mesosphere-cluster-high-availability/azuredeploy.json
+++ b/centos-mesosphere-cluster-high-availability/azuredeploy.json
@@ -60,10 +60,12 @@
             "defaultValue": "https://raw.githubusercontent.com/hausdorff/azurermtemplates/mesos_template/centos-mesosphere-cluster-high-availability/configure_slave.sh"
         },
         "masterConfigCommand": {
-            "type": "string"
+            "type": "string",
+            "defaultValue": "sh configure_master.sh"
         },
         "slaveConfigCommand": {
-            "type": "string"
+            "type": "string",
+            "defaultValue": "sh configure_slave.sh"
         },
         "sshKeyData" : {
             "type" : "string"

--- a/centos-mesosphere-cluster-simple/azuredeploy.json
+++ b/centos-mesosphere-cluster-simple/azuredeploy.json
@@ -60,10 +60,12 @@
             "defaultValue": "https://raw.githubusercontent.com/hausdorff/azurermtemplates/mesos_template/centos-mesosphere-cluster-simple/configure_slave.sh"
         },
         "masterConfigCommand": {
-            "type": "string"
+            "type": "string",
+            "defaultValue": "sh configure_master.sh"
         },
         "slaveConfigCommand": {
-            "type": "string"
+            "type": "string",
+            "defaultValue": "sh configure_slave.sh"
         },
         "sshKeyData" : {
             "type" : "string"


### PR DESCRIPTION
Mesosphere nodes are currently configured by downloading a shell script
from GitHub and running on each node. Currently the template is
configured to have a default config script to run, but not a default
command to run it. So users have to manually put in the command `sh
configure_master.sh` each time. This of course should come by default.

This commit will introduce those defaults to those templates.
