### PR TITLE
Removed legacy parameter from azuredeploy-parameters.json

### DIFF
--- a/datastax-on-ubuntu/azuredeploy-parameters.json
+++ b/datastax-on-ubuntu/azuredeploy-parameters.json
@@ -14,9 +14,6 @@
   "region": {
     "value": "West US"
   },
-  "opsCenterAdminUsername": {
-    "value": ""
-  },
   "opsCenterAdminPassword": {
     "value": ""
   },


### PR DESCRIPTION
"opsCenterAdminUsername" is no longer supported in the template, but remained in `azuredeploy-parameters.json`, throwing this error:

![screen shot 2015-04-20 at 9 30 43 pm](https://cloud.githubusercontent.com/assets/833774/7246409/cd5e6a80-e7b1-11e4-8df5-509d60895209.png)

This change removes the legacy parameter.
